### PR TITLE
Fix ipo calendar type

### DIFF
--- a/lib/Api/DefaultApi.php
+++ b/lib/Api/DefaultApi.php
@@ -11202,7 +11202,7 @@ class DefaultApi
      */
     public function ipoCalendar($from, $to)
     {
-        list($response) = $this->ipoCalendarWithHttpInfo($from, $to);
+        list($response) = $this->ipoCalendarWithHttpInfo($from->format('Y-m-d'), $to->format('Y-m-d'));
         return $response;
     }
 


### PR DESCRIPTION
IPO calendar method accept type \DateTime, but Guzzle does not accept DateTime type, so please change type to string or give result format method in DateTime class